### PR TITLE
Quote vars in statements for ansible 2.2.0

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -7,7 +7,7 @@
 
 - name: Debian | install packages
   apt: pkg={{ item }} state=installed
-  with_items: mysql_packages
+  with_items: "{{ mysql_packages }}"
   register: mysql_install
 
 - name: Debian | configure the service

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -7,7 +7,7 @@
 
 - name: RedHat | install packages
   yum: pkg={{ item }} state=installed
-  with_items: mysql_packages
+  with_items: "{{ mysql_packages }}"
   register: mysql_install
 
 - name: RedHat | configure the service

--- a/tasks/Suse.yml
+++ b/tasks/Suse.yml
@@ -7,7 +7,7 @@
 
 - name: Suse | install packages
   zypper: name={{ item }} state=installed
-  with_items: mysql_packages
+  with_items: "{{ mysql_packages }}"
   register: mysql_install
 
 - name: Suse | configure the service


### PR DESCRIPTION
Fix for Ansible 2.2.0 where variables in `with` blocks must be quoted.